### PR TITLE
Add lint verification to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
+      # Lint README for basic verification
+      - name: Lint Markdown
+        run: npx --yes markdownlint-cli README.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,19 @@
 name: CI Test
 
 "on":
+  push:
+    branches:
+      - main
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Select runner OS
+        required: true
+        default: ubuntu-latest
+        type: choice
+        options:
+          - ubuntu-latest
+          - ubuntu-22.04
 
 jobs:
   check:
@@ -11,11 +23,11 @@ jobs:
     outputs:
       os: ${{ steps.check_event.outputs.os }}
     steps:
-      - name: Check event
+      - name: Determine runner OS
         id: check_event
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo 'os=ubuntu-latest' >> $GITHUB_OUTPUT
+            echo "os=${{ github.event.inputs.runner }}" >> $GITHUB_OUTPUT
           else
             echo 'os=ubuntu-22.04' >> $GITHUB_OUTPUT
           fi

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-
 # Hi 👋
 
 ![Alishen's GitHub stats](https://alisen-stats.vercel.app/api?username=alisen&show_icons=true)
 <!-- [![Top Langs](
   https://github-readme-stats.vercel.app/api/top-langs/?username=alisen&theme=dark
 )](https://github.com/anuraghazra/github-readme-stats) -->
-- 👨‍💻 I’m currently working on diconium
+- 👨‍💻 I’m currently working at diconium
 - I’m currently learning German
 - 👍 Gaming 🎮 Cycling 🚴🏻‍♂️
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-### Hi 👋
+
+# Hi 👋
+
 ![Alishen's GitHub stats](https://alisen-stats.vercel.app/api?username=alisen&show_icons=true)
-<!-- [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=alisen&theme=dark)](https://github.com/anuraghazra/github-readme-stats) -->
+<!-- [![Top Langs](
+  https://github-readme-stats.vercel.app/api/top-langs/?username=alisen&theme=dark
+)](https://github.com/anuraghazra/github-readme-stats) -->
 - 👨‍💻 I’m currently working on diconium
 - I’m currently learning German
 - 👍 Gaming 🎮 Cycling 🚴🏻‍♂️


### PR DESCRIPTION
## Summary
- update README formatting so markdownlint passes
- run markdownlint-cli in CI instead of echo

## Testing
- `npx --yes markdownlint-cli README.md`

------
https://chatgpt.com/codex/tasks/task_e_6840e805f3c8833388c134fc7731296c