### PR TITLE
Improve workflow OS selection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,19 @@
 name: CI Test
 
 "on":
+  push:
+    branches:
+      - main
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Select runner OS
+        required: true
+        default: ubuntu-latest
+        type: choice
+        options:
+          - ubuntu-latest
+          - ubuntu-22.04
 
 jobs:
   check:
@@ -11,11 +23,11 @@ jobs:
     outputs:
       os: ${{ steps.check_event.outputs.os }}
     steps:
-      - name: Check event
+      - name: Determine runner OS
         id: check_event
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo 'os=ubuntu-latest' >> $GITHUB_OUTPUT
+            echo "os=${{ github.event.inputs.runner }}" >> $GITHUB_OUTPUT
           else
             echo 'os=ubuntu-22.04' >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Summary
- add `push` trigger and workflow dispatch input for selecting the runner
- restore conditional OS selection logic

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 120}}}' .github/workflows/test.yml`

------
https://chatgpt.com/codex/tasks/task_e_6840e80430b08333b3ead5ca6942f85d