### PR TITLE
Integrate github breakout into alisen repo

### DIFF
--- a/.github/workflows/generate-breakout.yml
+++ b/.github/workflows/generate-breakout.yml
@@ -1,0 +1,39 @@
+name: generate breakout svg
+
+on:
+  schedule:
+    - cron: "0 */24 * * *"
+  workflow_dispatch:
+
+jobs:
+  generate-svg:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: generate SVG
+        uses: cyprieng/github-breakout@v1.0.0
+        with:
+          github_username: ${{ github.repository_owner }}
+
+      - name: Move generated SVGs
+        run: |
+          mkdir -p images
+          mv output/light.svg images/breakout-light.svg
+          mv output/dark.svg images/breakout-dark.svg
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit and push SVGs
+        run: |
+          git add images/breakout-light.svg images/breakout-dark.svg
+          git commit -m "chore: update breakout SVGs" || echo "No changes to commit"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,8 +1,21 @@
 ### Hi 👋
+
+<picture>
+  <source
+    media="(prefers-color-scheme: dark)"
+    srcset="images/breakout-dark.svg"
+  />
+  <source
+    media="(prefers-color-scheme: light)"
+    srcset="images/breakout-light.svg"
+  />
+  <img alt="Breakout Game" src="images/breakout-light.svg" />
+</picture>
+
 ![Alishen's GitHub stats](https://alisen-stats.vercel.app/api?username=alisen&show_icons=true)
 <!-- [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=alisen&theme=dark)](https://github.com/anuraghazra/github-readme-stats) -->
-- 👨‍💻 I’m currently working at diconium
-- I’m currently learning German
+- 👨‍💻 I'm currently working at diconium
+- I'm currently learning German
 - 👍 Gaming 🎮 Cycling 🚴🏻‍♂️
 
 [![@alishen's Holopin board](https://holopin.io/api/user/board?user=alishen)](https://holopin.io/@alishen)


### PR DESCRIPTION
Integrate GitHub Breakout game to display contribution graph as an interactive SVG on the profile README.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7aac5db-b1e4-4f82-9ac0-05fbd51fc815">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e7aac5db-b1e4-4f82-9ac0-05fbd51fc815">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

